### PR TITLE
Remove errant console.log when running tests

### DIFF
--- a/test/index.js
+++ b/test/index.js
@@ -214,7 +214,6 @@ function testParseSection() {
 function testParseIndexes() {
   var text = "abc{{#foo}}asdf{{bar}}asdf{{/foo}}def";
   var tree = Hogan.parse(Hogan.scan(text));
-  console.log(JSON.stringify(tree));
   is(text.substring(tree[1].i, tree[1].end), "asdf{{bar}}asdf", "section text indexes are correct");
 }
 


### PR DESCRIPTION
This change removes a stray `console.log` I found when running the tests via the console.
