### PR TITLE
Included options.asString in cache key to separate caching of string and object versions of a template.

### DIFF
--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -334,13 +334,15 @@
     //
     options = options || {};
 
-    var t = this.cache[text];
+    var key = text + '||' + !!options.asString;
+
+    var t = this.cache[key];
 
     if (t) {
       return t;
     }
 
     t = this.generate(writeCode(this.parse(this.scan(text, options.delimiters), options)), text, options);
-    return this.cache[text] = t;
+    return this.cache[key] = t;
   };
 })(typeof exports !== 'undefined' ? exports : Hogan);


### PR DESCRIPTION
After compiling a template as a string, the cache prevents the template from being compiled a second time as an object. And vice versa. Adding the value of `options.asString` to the cache key solves the issue.
