### PR TITLE
A more Windows friendly compile script

### DIFF
--- a/bin/hogan-compile.js
+++ b/bin/hogan-compile.js
@@ -1,28 +1,85 @@
 #!/usr/bin/env node
 /*
- * Compiles Hogan templates and prints result to stdout
+ * Compiles Hogan templates and prints result to stdout 
  */
+ var hogan = require('../lib/hogan.js'),
+     path = require('path'),
+     fs = require('fs');
 
-var hogan = require('../lib/hogan'),
-    path = require('path'),
-    fs = require('fs');
-
-// we assume that argv[2] is a list of files, or a directory
-// that contains mustache templates
-var argv = process.argv.slice(2);
-
-var output = [];
-
-
-argv.map(function(filePath) {
-    var fullPath = path.resolve(__dirname, filePath),
-        openedFile = fs.readFileSync(fullPath, 'utf-8'),
-        name = path.basename(filePath, '.mustache');
-    if (openedFile) {
-        output.push("'" + name + "': new Hogan.Template(" + hogan.compile(openedFile, {asString:true}) + ")");
+function processArgs( argv ) {
+  var args = {}, i;
+  for ( i = 0; i < argv.length; i++ ) {
+    if ( argv[i].charAt( 0 ) === '-' ) {
+      args[ argv[i] ] = argv[++i];
+      continue;
     }
-});
+    break;
+  }
+  if ( i < argv.length ) {
+    args[ 'templatefiles' ] = argv.slice(i);
+  }
+  return Object.keys( args ).length > 0 ? args : false;
+}
 
-process.stdout.write('var HoganTemplates = {' + output.join(',\n') + '};\n');
+function checkArgs( args ) {
+  usage = 'Usage: hogan-compile.js (-td <template-directory>) (-ext <template-extension>) template files\n' +
+          '  example: hogan-compile.js templates/*.mustache\n' +
+          '  example: hogan-compile.js -td templates';
+  
+  if ( !args ) {
+    process.stderr.write( usage );
+    process.exit(-1);
+  }
 
-process.exit(0);
+  var templatePath  = args['-td'],
+      templateExt   = args['-ext'] || '.mustache'
+      templateFiles = args['templatefiles'];
+  
+  if ( !templatePath && !templateFiles ) {
+    process.stderr.write( "A template directory or template files wasn't specified.\n" );
+    process.stderr.write( usage );
+    process.exit(-1);
+  } 
+  if ( templatePath ) {
+    if ( !path.existsSync( templatePath ) ) {
+      process.stderr.write( "template directory '" + templatePath + "' doesn't exists\n" );
+      process.stderr.write( usage );
+      process.exit(-1);
+    }
+    templateFiles = fs.readdirSync( templatePath ).map( function( f ) { return path.join( templatePath, f ) } );
+  }
+  return { templateExt : templateExt, templateFiles : templateFiles };
+}
+
+function hasExtension( file, extension ) {
+  return file.indexOf(extension, file.length - extension.length) !== -1;
+}
+
+function removeByteOrderMark( text ) {
+  // Remove utf-8 byte order mark, http://en.wikipedia.org/wiki/Byte_order_mark
+  if ( text.charCodeAt( 0 ) === 0xfeff ) {   
+    return text.substring( 1 );
+  }
+  return text;
+}
+var args = checkArgs( processArgs( process.argv.slice(2) ) );
+
+console.log( 'var templates = {}' );
+// Write a template foreach file that macthes template extension
+args.templateFiles.forEach( function(file) {
+
+  if ( hasExtension( file, args.templateExt ) ) {
+    var openedFile = fs.readFileSync(file, 'utf-8');
+    
+    if (openedFile) { 
+      var name = path.basename(file, args.templateExt),
+          templateName = 'templates.' + name,
+          compiledName = templateName + '_c';
+      
+      openedFile = removeByteOrderMark( openedFile.trim() );
+           
+      console.log( compiledName + ' = ' + hogan.compile(openedFile, {asString: true}) + ';' );
+      console.log( templateName + ' = new Hogan.Template( '+ compiledName + ', "' + name + '" );' );
+    }
+  }
+} );


### PR DESCRIPTION
Some suggestions to the compile script, that adds following functionality which makes my life on Windows a little easier.

As Windows doesn't support shell wildcard expansion, the script supports an option (-td) for specifying a directory to load template files from. (http://blogs.msdn.com/b/dancre/archive/2005/05/14/417547.aspx)

Many editors in Windows add a Byte Order Mark to UTF-8 encoded files (http://en.wikipedia.org/wiki/Byte_order_mark). This caused the compiled templates to include the Byte Order Mark when the templates were rendered. The script will remove the Byte Order Mark if present. I'm not sure that I did that the right way or if the Node.js file api support this in some way (please enlighten me).

I also added an option for specifying the file extension of the template files.

The script can be used like this:
`hogan-compile.js (-td <template-dir>) (-ext <template-ext>) template files
  example: hogan-compile.js templates/*.mustache
  example: hogan-compile.js -td templates
`

When the -td option is used any "template files" are ignored
