### PR TITLE
Use base filename as template name

### DIFF
--- a/bin/hulk
+++ b/bin/hulk
@@ -78,7 +78,7 @@ templates = extractFiles(process.argv.slice(2))
   .map(function (file) {
     var openedFile = fs.readFileSync(file, 'utf-8'), name;
     if (!openedFile) return;
-    name = file.replace(/\..*$/, '');
+    name = path.basename( file ).replace(/\..*$/, '');
     openedFile = removeByteOrderMark(openedFile.trim());
     return 'templates.' + name + ' = new Hogan.Template(' + hogan.compile(openedFile, { asString: 1 }) + ');';
   })


### PR DESCRIPTION
when running 

``` bash
$ bin/hulk test/templates/*.mustache
```

on Windows, the following is generated

``` javascript
var templates = {};
templates.test/templates/list = new Hogan.Template( .....
```

With the proposed change this is generated

``` javascript
var templates = {};
templates.list = new Hogan.Template( .....
```
