### PR TITLE
Use path.basename to generate template keys.

### DIFF
--- a/bin/hulk
+++ b/bin/hulk
@@ -78,7 +78,7 @@ templates = extractFiles(process.argv.slice(2))
   .map(function (file) {
     var openedFile = fs.readFileSync(file, 'utf-8'), name;
     if (!openedFile) return;
-    name = file.replace(/\..*$/, '');
+    name = path.basename(file.replace(/\..*$/, ''));
     openedFile = removeByteOrderMark(openedFile.trim());
     return 'templates.' + name + ' = new Hogan.Template(' + hogan.compile(openedFile, { asString: 1 }) + ');';
   })


### PR DESCRIPTION
If you run `bin/hogan` from a directory quite deep, you end up with
template reference names like:

```
templates./home/user/work/static/js/templates/_simple_view = new Hogan.Template...
```

which is obviously invalid Javascript.

This fixes it to use `path.basename` wrapped around the output, leaving us
with:

```
templates._simple_view = new Hogan.Template...
```

Which is a lot better Javascript-wise.
