### PR TITLE
Fix lambda usage bug with precompiled mustache templates

### DIFF
--- a/bin/hulk
+++ b/bin/hulk
@@ -87,8 +87,11 @@ function oneLineJsMatcher(match) {
       break;
           
     case '\r\n':
+      retVal ='\\r\\n';
+      break;
+
     case '\n':
-      retVal = '';
+      retVal = '\\n';
       break;
   }
 


### PR DESCRIPTION
Allows lambdas to be used in precompiled mustache templates by passing raw template text and Hogan 'compiler' to Hogan.Template constructor (help from @JamesShuttler).
