### PR TITLE
Fix Node.js wrapper.

### DIFF
--- a/lib/hogan.js
+++ b/lib/hogan.js
@@ -17,4 +17,5 @@
 
 var Hogan = require('./compiler');
 Hogan.Template = require('./template').Template;
-module.exports = Hogan; 
+Hogan.template = Hogan.Template;
+module.exports = Hogan;


### PR DESCRIPTION
When `compiler.js` is used as a module, it operates on the empty `exports` object, without `Hogan.Template`. This causes `Hogan.template` to be `undefined`, and Hogan.js to throw an error when trying to instantiate it.

This patch hooks `Hogan.template` up in the Node.js wrapper; it's not needed in the browser.

The bug also occurs in `make release`.
