### PR TITLE
Fix Scanner Indexes of Section With Uneven Reset Delimiters

### DIFF
--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -135,7 +135,7 @@
       } else {
         if (tagChange(ctag, text, i)) {
           tokens.push({tag: tagType, n: trim(buf), otag: otag, ctag: ctag,
-                       i: (tagType == '/') ? seenTag - ctag.length : i + otag.length});
+                       i: (tagType == '/') ? seenTag - otag.length : i + ctag.length});
           buf = '';
           i += ctag.length - 1;
           state = IN_TEXT;

--- a/test/index.js
+++ b/test/index.js
@@ -1066,3 +1066,17 @@ test("Default Render Impl", function() {
   var ht = new Hogan.Template();
   is(ht.render() === '', true, 'default renderImpl returns an array.');
 });
+
+test("Section With Custom Uneven Delimiter Length", function() {
+  var text = '{{=<% %%>=}}Test<%#foo%%>bar<%/foo%%>';
+  var t = Hogan.compile(text);
+  var context = {
+    foo: function() {
+      return function(s) {
+        return "<b>" + s + "</b>";
+      }
+    }
+  }
+  var s = t.render(context);
+  is(s, 'Test<b>bar</b>', 'Section content is correct with uneven reset delimiter length');
+});


### PR DESCRIPTION
I ran into this when I was porting Hogan.js and my text editor added an extra brace to one of the unit tests I was copying. Basically, there's a problem if you use reset delimiters and they are of different lengths with sections and lambdas:

`{{=<% %%>=}}Test<%#foo%%>bar<%/foo%%>`

The scanner will calculate the index to get the substring inside the #foo section to be '>ba' (actual) instead of 'bar' (expected). Simple change and I've added a unit test that checks.
