### PR TITLE
template inheritance has problems with newlines

### DIFF
--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -298,7 +298,7 @@
       template.partials[key] = this.makePartials(template.partials[key]);
     }
     for (key in codeObj.subs) {
-      template.subs[key] = new Function('c', 'p', 't', codeObj.subs[key]);
+      template.subs[key] = new Function('c', 'p', 't', 'i', codeObj.subs[key]);
     }
     return template;
   }
@@ -351,7 +351,7 @@
       Hogan.walk(node.nodes, ctx);
       context.subs[node.n] = ctx.code;
       if (!context.inPartial) {
-        context.code += 't.sub("' + esc(node.n) + '",c,p);';
+        context.code += 't.sub("' + esc(node.n) + '",c,p,i);';
       }
     },
 

--- a/lib/template.js
+++ b/lib/template.js
@@ -241,10 +241,10 @@ var Hogan = {};
       return result;
     },
 
-    sub: function(name, context, partials) {
+    sub: function(name, context, partials, indent) {
       var f = this.subs[name];
       if (f) {
-        f(context, partials, this);
+        f(context, partials, this, indent);
       }
     }
 

--- a/test/index.js
+++ b/test/index.js
@@ -795,6 +795,22 @@ test("Two overridden partials with different content", function() {
   is(s, 'test |override1 default| |override2 default|');
 });
 
+test("Override partial with newlines", function() {
+  var partial = "{{$ballmer}}peaking{{/ballmer}}";
+  var template = "{{<partial}}{{$ballmer}}\npeaked\n\n:(\n{{/ballmer}}{{/partial}}";
+  var t = Hogan.compile(template);
+  var s = t.render({}, {"partial": partial});
+  is(s, "peaked\n\n:(\n");
+});
+
+test("Inherit indentation when overriding a partial", function() {
+  var partial = "stop:\n  {{$nineties}}collaborate and listen{{/nineties}}";
+  var template = "{{<partial}}{{$nineties}}hammer time{{/nineties}}{{/partial}}";
+  var t = Hogan.compile(template);
+  var s = t.render({}, {"partial": partial});
+  is(s, "stop:\n  hammer time");
+});
+
 test("Override one substitution but not the other", function() {
   var partial = Hogan.compile("{{$stuff}}default one{{/stuff}}, {{$stuff2}}default two{{/stuff2}}");
   var template = "{{<partial}}{{$stuff2}}override two{{/stuff2}}{{/partial}}";


### PR DESCRIPTION
It seems like template inheritance, as it stands, gets bamboozled by newlines. The test I added checks for this. Any idea why this might be happening?
