### PR TITLE
Fix lambdas getting wrong arguments in inheritance subsections

### DIFF
--- a/lib/template.js
+++ b/lib/template.js
@@ -71,7 +71,7 @@ var Hogan = {};
       this.partials[symbol].base = template;
 
       if (partial.subs) {
-        template = createSpecializedPartial(template, partial.subs, partial.partials);
+        template = createSpecializedPartial(template, partial.subs, partial.partials, this.text);
       }
 
       this.partials[symbol].instance = template;
@@ -215,14 +215,16 @@ var Hogan = {};
 
     // method replace section
     ms: function(func, ctx, partials, inverted, start, end, tags) {
-      var cx = ctx[ctx.length - 1],
+      var textSource,
+          cx = ctx[ctx.length - 1],
           result = func.call(cx);
 
       if (typeof result == 'function') {
         if (inverted) {
           return true;
         } else {
-          return this.ls(result, cx, partials, this.text.substring(start, end), tags);
+          textSource = (this.activeSub && this.subsText[this.activeSub]) ? this.subsText[this.activeSub] : this.text;
+          return this.ls(result, cx, partials, textSource.substring(start, end), tags);
         }
       }
 
@@ -244,13 +246,15 @@ var Hogan = {};
     sub: function(name, context, partials, indent) {
       var f = this.subs[name];
       if (f) {
+        this.activeSub = name;
         f(context, partials, this, indent);
+        this.activeSub = false;
       }
     }
 
   };
 
-  function createSpecializedPartial(instance, subs, partials) {
+  function createSpecializedPartial(instance, subs, partials, childText) {
     function PartialTemplate() {};
     PartialTemplate.prototype = instance;
     function Substitutions() {};
@@ -258,10 +262,12 @@ var Hogan = {};
     var key;
     var partial = new PartialTemplate();
     partial.subs = new Substitutions();
+    partial.subsText = {};  //hehe. substext.
     partial.ib();
 
     for (key in subs) {
       partial.subs[key] = subs[key];
+      partial.subsText[key] = childText;
     }
 
     for (key in partials) {

--- a/test/index.js
+++ b/test/index.js
@@ -1100,3 +1100,18 @@ test("Section With Custom Uneven Delimiter Length", function() {
   var s = t.render(context);
   is(s, 'Test<b>bar</b>', 'Section content is correct with uneven reset delimiter length');
 });
+
+
+test("Lambda expression in inherited template subsections", function() {
+    var lambda = function() {
+        return function(argument) {
+            return 'altered ' + argument;
+        }
+    }
+    var partial = '{{$section1}}{{#lambda}}parent1{{/lambda}}{{/section1}} - {{$section2}}{{#lambda}}parent2{{/lambda}}{{/section2}}';
+    var text = '{{< partial}}{{$section1}}{{#lambda}}child1{{/lambda}}{{/section1}}{{/ partial}}'
+    var template = Hogan.compile(text);
+
+    var result = template.render({lambda: lambda}, {partial: Hogan.compile(partial)});
+    is(result, 'altered child1 - altered parent2', 'Lambda replacement failed with template inheritance');
+});


### PR DESCRIPTION
This is a simple fix for issue #80.

I'm honestly not that keen on the way I implemented this fix. I don't really like the way it tracks the subsection state in the special partial template, but the other implementations I considered would have required altering much more code, and I'm not sure I grok it well enough for that yet, so I opted for the change that touched the fewest lines.

I'm happy to work on a different approach with feedback.
