### PR TITLE
Fixes client-side rendering

### DIFF
--- a/lib/template.js
+++ b/lib/template.js
@@ -18,14 +18,14 @@ var Hogan = {};
 (function (Hogan, useArrayBuffer) {
   Hogan.Template = function (codeObj, text, compiler, options) {
     codeObj = codeObj || {};
-    this.r = codeObj.code || this.r;
+    this.r = (typeof codeObj == 'function') ? codeObj : codeObj.code || this.r;
     this.c = compiler;
     this.options = options;
     this.text = text || '';
     this.partials = codeObj.partials || {};
     this.subs = codeObj.subs || {};
     this.ib();
-  }
+  };
 
   Hogan.Template.prototype = {
     // render: replaced by generated code.


### PR DESCRIPTION
Fixes the case where you compile the templates on the server into functions, then serve them to the frontend for use.

Example: 

On the server:

```
var hogan = require('hogan.js');
var tpl = require('fs').readFileSync('./template.mu', 'utf8');
console.log("var template = " + hogan.compile(tpl, {asString : true})); // Save output file as `template.js`
```

On the client:

```
<script src="hogan.template.js" type="text/javascript"></script>
<script src="template.js" type="text/javascript"></script>

<script type="text/javascript">
  console.log(template); // Compiled function from hogan.compile(..., {asString : true});
  console.log(template.code); // undefined, leading to "" as output (this is the problem)

  var compiled = new Hogan.Template(template);
  console.log(compiled.render({planet : { home : "Earth"}})); // => "Hello Earth!"
</script>
```
