### PR TITLE
Fixes for variable scope and wildcard directory issues in Hulk

### DIFF
--- a/bin/hulk
+++ b/bin/hulk
@@ -91,7 +91,8 @@ function extractFiles(args) {
       return files = files.concat(
         fs.readdirSync(arg[0] || '.')
           .map(function (f) {
-            return new RegExp(esc(arg[1]) + '$').test(f) && fs.statSync(path.join(arg[0], f)).isFile();
+            var file = path.join(arg[0], f);
+            return new RegExp(esc(arg[1]) + '$').test(f) && fs.statSync(file).isFile() && file;
           })
           .filter(function (f) {
             return f;


### PR DESCRIPTION
### Summary of Issues fixed in this Pull Request

**Variable scope issues (console)** 

The templates variable in Hulk output is never declared before attempting to initialize it, resulting in Uncaught `ReferenceErrors`.  This is currently causing the Hulk tests to fail when attempting to `eval(stdout)` and errors to occur in the browser when importing the template as a script. 

```
if (!!!templates) templates = {};
templates["test1"] = new Hogan.Template({code: function (c,p,i) { var t=this;t.b(i=i||"");t.b("<p>");t.b(t.v(t.f("test",c,p,0)));t.b("</p>");return t.fl(); },partials: {}, subs: {  }});
```

**Variable scope issues (outputdir)**

When passing the `--outputdir` flag to Hulk, individual `.js` templates are generated for each file, but these individual templates cannot be imported/loaded as they are missing a templates variable declaration.  The output only includes the compiled template with its wrapper:

```
templates["test"] = new Hogan.Template({code: function (c,p,i) { var t=this;t.b(i=i||"");t.b("<p>");t.b(t.v(t.f("test",c,p,0)));t.b("</p>");return t.fl(); },partials: {}, subs: {  }});
```

Without the variable declaration, there isn't much of a point in generating the individual `.js` templates, as they cannot be imported as-is.  It could be argued they are not meant to be imported individually, but rather concatenated and wrapped by an additional process, but in that case it makes more sense to pipe the console output to a file. 

**Wildcard with sub-directories issue**

If a wildcard is passed to Hulk for a directory which contains sub-directories, Hulk will attempt to process sub-directories as files with `fs.readFileSync(sub-directory, 'utf-8')`.  The result of this operation is an `illegal operation on a directory` error.

**Miscellaneous**

Added line-breaks where necessary to standardize on two line-breaks before comments.
