### PR TITLE
Fixes for variable scope and wildcard issues in Hulk

### DIFF
--- a/bin/hulk
+++ b/bin/hulk
@@ -15,12 +15,14 @@
  *  limitations under the License.
  */
 
+
 // dependencies
 var hogan  = require('../lib/hogan.js')
   , path   = require('path')
   , nopt   = require('nopt')
   , mkderp = require('mkdirp')
   , fs     = require('fs');
+
 
 // locals
 var specials       = ['/', '.', '*', '+', '?', '|','(', ')', '[', ']', '{', '}', '\\']
@@ -42,6 +44,7 @@ var specials       = ['/', '.', '*', '+', '?', '|','(', ')', '[', ']', '{', '}',
     'v': ['--version']
     }
   , templates;
+
 
 // options
 options = nopt(options, shortHand);
@@ -88,7 +91,8 @@ function extractFiles(args) {
       return files = files.concat(
         fs.readdirSync(arg[0] || '.')
           .map(function (f) {
-            return new RegExp(esc(arg[1]) + '$').test(f) && path.join(arg[0], f);
+            var file = path.join(arg[0], f);
+            return new RegExp(esc(arg[1]) + '$').test(f) && fs.statSync(file).isFile() && file;
           })
           .filter(function (f) {
             return f;
@@ -96,7 +100,7 @@ function extractFiles(args) {
       );
     }
 
-    files.push(arg);
+    if (fs.statSync(arg).isFile()) files.push(arg);
 
   })
 
@@ -126,15 +130,18 @@ function wrap(file, name, openedFile) {
   }
 }
 
+
 // write the directory
 if (options.outputdir) {
   mkderp.sync(options.outputdir);
 }
 
+
 // Prepend namespace to template name
 function namespace(name) {
     return (options.namespace || '') + name;
 }
+
 
 // write a template foreach file that matches template extension
 templates = extractFiles(options.argv.remain)
@@ -145,7 +152,9 @@ templates = extractFiles(options.argv.remain)
     openedFile = removeByteOrderMark(openedFile.trim());
     openedFile = wrap(file, name, openedFile);
     if (!options.outputdir) return openedFile;
-    fs.writeFileSync(path.join(options.outputdir, name + '.js'), openedFile);
+    var vn = options.variable || 'templates';
+    fs.writeFileSync(path.join(options.outputdir, name + '.js')
+      , 'if (!!!' + vn + ') var ' + vn + ' = {};\n' + openedFile);
   })
   .filter(function (t) {
     return t;
@@ -156,6 +165,6 @@ templates = extractFiles(options.argv.remain)
 if (!templates.length || options.outputdir) process.exit(0);
 if (!options.wrapper) {
   var vn = options.variable || 'templates';
-  console.log('if (!!!' + vn + ') ' + vn + ' = {};');
+  console.log('if (!!!' + vn + ') var ' + vn + ' = {};');
 }
 console.log(templates.join('\n'));


### PR DESCRIPTION
### Summary of Issues fixed in this Pull Request

**Variable scope issues (console)** 

The templates variable in the Hulk console output is never declared before attempting to initialize it, resulting in Uncaught `ReferenceErrors`.  This is currently causing the Hulk tests to fail when attempting to `eval(stdout)` and errors to occur in the browser when importing the template as a script. 

**Variable scope issues (outputdir)**

When passing the `--outputdir` flag to Hulk, individual `.js` templates are generated for each file, but these individual templates cannot be imported/loaded as they are missing a templates variable declaration.  The output only includes the compiled template with its wrapper:

```
templates["test"] = new Hogan.Template({code: function (c,p,i) { var t=this;t.b(i=i||"");t.b("<p>");t.b(t.v(t.f("test",c,p,0)));t.b("</p>");return t.fl(); },partials: {}, subs: {  }});
```

Without the variable declaration, there isn't much of a point in generating the individual `.js` templates, as they cannot be imported as-is.  It could be argued they are not meant to be imported individually, but rather concatenated and wrapped by an additional process, but in that case it makes more sense to pipe the console output to a file. 

**Wildcard with sub-directories issue**

If a wildcard is passed to Hulk for a directory which contains sub-directories, Hulk will attempt to process those sub-directories as files with `fs.readFileSync(sub-directory, 'utf-8')`.  Since a directory cannot be read as a file, this results in an `illegal operation on a directory` error.

**Miscellaneous**

Added line-breaks where necessary to standardize on two line-breaks before comments.
