### PR TITLE
Add overflow to the code blocks

### DIFF
--- a/stylesheets/layout.css
+++ b/stylesheets/layout.css
@@ -172,7 +172,7 @@ pre, code {
 	padding: 5px 10px;
 	margin-bottom: 20px;
 	font-family: courier;
-	overflow: hidden;
+	overflow: auto;
 }
 
 pre code {


### PR DESCRIPTION
Currently, the part labeled:

`Alternatively, drop hogan.js in your browser by adding the following script.`

has a code block that requires copy+pasting. However, as there is no overflow on the box, it's pretty hard to select the text correctly. This is a fix to that problem.
