### PR TITLE
npmignore unneeded files

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,5 @@
+test
+tools
+web
+wrappers
+Makefile


### PR DESCRIPTION
No point in wasting bandwidth and space. This would make the module almost 1MB smaller. Size matters since it's used by Bower.
