### PR TITLE
Support for deep inheritance substitutions

### DIFF
--- a/lib/template.js
+++ b/lib/template.js
@@ -76,9 +76,11 @@ var Hogan = {};
           // Store parent template text in partials.stackText to perform substitutions in child templates correctly
           partials.stackText  = this.text;
         }
-         template = createSpecializedPartial(template, partial.subs, partial.partials, partials.stackText || this.text);
-       }
+        template = createSpecializedPartial(template, partial.subs, partial.partials,
+          this.stackSubs, this.stackPartials, partials.stackText || this.text);
+      }
       this.partials[symbol].instance = template;
+
       return template;
     },
 
@@ -280,7 +282,7 @@ var Hogan = {};
     return val;
   }
 
-  function createSpecializedPartial(instance, subs, partials, childText) {
+  function createSpecializedPartial(instance, subs, partials, stackSubs, stackPartials, childText) {
     function PartialTemplate() {};
     PartialTemplate.prototype = instance;
     function Substitutions() {};
@@ -291,13 +293,23 @@ var Hogan = {};
     partial.subsText = {};  //hehe. substext.
     partial.ib();
 
+    stackSubs = stackSubs || {};
+    partial.stackSubs = stackSubs;
     for (key in subs) {
-      partial.subs[key] = subs[key];
+      if (!stackSubs[key]) stackSubs[key] = subs[key];
       partial.subsText[key] = childText;
     }
+    for (key in stackSubs) {
+      partial.subs[key] = stackSubs[key];
+    }
 
+    stackPartials = stackPartials || {};
+    partial.stackPartials = stackPartials;
     for (key in partials) {
-      partial.partials[key] = partials[key];
+      if (!stackPartials[key]) stackPartials[key] = partials[key];
+    }
+    for (key in stackPartials) {
+      partial.partials[key] = stackPartials[key];
     }
 
     return partial;

--- a/test/index.js
+++ b/test/index.js
@@ -859,7 +859,7 @@ test("Recursion in inherited templates", function() {
   var include2 = Hogan.compile("{{$foo}}include2 default content{{/foo}} {{<include}}{{$bar}}don't recurse{{/bar}}{{/include}}");
   var t = Hogan.compile("{{<include}}{{$foo}}override{{/foo}}{{/include}}");
   var s = t.render({}, {include: include, include2: include2});
-  is(s, "override include2 default content default content don't recurse", "matches expected recursive output");
+  is(s, "override override override don't recurse", "matches expected recursive output");
 });
 
 test("Doesn't parse templates that have non-$ tags inside super template tags", function() {
@@ -912,6 +912,22 @@ test("Issue #62: partial references inside substitutions should work", function 
   };
 
   is(templates.main.render({}, templates), templatesAsString.main.render({}, templatesAsString))
+});
+
+test("Top-level substitutions take precedence in multi-level inheritance", function() {
+  var child = Hogan.compile('{{<parent}}{{$a}}c{{/a}}{{/parent}}').render({}, {
+    parent: '{{<older}}{{$a}}p{{/a}}{{/older}}',
+    older: '{{<grandParent}}{{$a}}o{{/a}}{{/grandParent}}',
+    grandParent: '{{$a}}g{{/a}}'
+  });
+  is(child, 'c', 'should use the child sub value');
+
+  var noSubChild = Hogan.compile('{{<parent}}{{/parent}}').render({}, {
+    parent: '{{<older}}{{$a}}p{{/a}}{{/older}}',
+    older: '{{<grandParent}}{{$a}}o{{/a}}{{/grandParent}}',
+    grandParent: '{{$a}}g{{/a}}'
+  });
+  is(noSubChild, 'p', 'should use the parent\'s value');
 });
 
 /* Safety tests */


### PR DESCRIPTION
This will allow a user to be able to substitute a value at any level of inheritance, not just for the direct parent. 

It is for the jinja-like use-case described in https://github.com/mustache/spec/issues/38 and illustrated in https://gist.github.com/mcheely/3220568

This PR resolves also issue https://github.com/twitter/hogan.js/issues/110

Note: There is one more part to this for this to be completely ready; that is—substituting lambdas that are in grand-parents or further up/down the stack. I'm looking into that now; but if you see a way for clean implementation, please let me know.
