### PR TITLE
Clean partials instance before returning cache

### DIFF
--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -406,6 +406,10 @@
     var template = this.cache[key];
 
     if (template) {
+      var partials = template.partials;
+      for (var name in partials) {
+        delete partials[name].instance;
+      }
       return template;
     }
 

--- a/test/index.js
+++ b/test/index.js
@@ -862,6 +862,32 @@ test("Recursion in inherited templates", function() {
   is(s, "override override override don't recurse", "matches expected recursive output");
 });
 
+test("Cache contains old partials instances", function() {
+  var tests = [{
+    template: "{{<parent}}{{$a}}c{{/a}}{{/parent}}",
+    partials: {
+      parent: "{{<grandParent}}{{$a}}p{{/a}}{{/grandParent}}",
+      grandParent: "{{$a}}g{{/a}}"
+    },
+    expected: "c"
+  }, {
+    template: "{{<parent}}{{/parent}}",
+    partials:{
+      parent: "{{<grandParent}}{{$a}}p{{/a}}{{/grandParent}}",
+      grandParent: "{{$a}}g{{/a}}"
+    },
+    expected: "p"
+  }];
+  tests.forEach(function(test) {
+    var partials = {};
+    for (var i in test.partials) {
+      partials[i] = Hogan.compile(test.partials[i]);
+    }
+    var output = Hogan.compile(test.template).render({}, partials);
+    is(output, test.expected);
+  });
+});
+
 test("Doesn't parse templates that have non-$ tags inside super template tags", function() {
   var msg = "";
   try {


### PR DESCRIPTION
This fixes the issue @dtb pointed out in #161.

The problem was that hogan did not clean-up the template `.instance` it created for the "specialized partial"; so on the first run it created the instance and on subsequent calls the cache returned the old instances; which contained old data from the previous run.

This PR cleans up the instances before returning the template cache to the client in `.compile()`
