### PR TITLE
Lambdas in multi level inheritance

### DIFF
--- a/lib/template.js
+++ b/lib/template.js
@@ -72,12 +72,14 @@ var Hogan = {};
 
       if (partial.subs) {
         // Make sure we consider parent template now
-        if (this.activeSub === undefined) {
-          // Store parent template text in partials.stackText to perform substitutions in child templates correctly
-          partials.stackText  = this.text;
+        if (!partials.stackText) partials.stackText = {};
+        for (key in partial.subs) {
+          if (!partials.stackText[key]) {
+            partials.stackText[key] = (this.activeSub !== undefined && partials.stackText[this.activeSub]) ? partials.stackText[this.activeSub] : this.text;
+          }
         }
         template = createSpecializedPartial(template, partial.subs, partial.partials,
-          this.stackSubs, this.stackPartials, partials.stackText || this.text);
+          this.stackSubs, this.stackPartials, partials.stackText);
       }
       this.partials[symbol].instance = template;
 
@@ -233,7 +235,7 @@ var Hogan = {};
         if (inverted) {
           return true;
         } else {
-          textSource = (this.activeSub && this.subsText[this.activeSub]) ? this.subsText[this.activeSub] : this.text;
+          textSource = (this.activeSub && this.subsText && this.subsText[this.activeSub]) ? this.subsText[this.activeSub] : this.text;
           return this.ls(result, cx, partials, textSource.substring(start, end), tags);
         }
       }
@@ -282,7 +284,7 @@ var Hogan = {};
     return val;
   }
 
-  function createSpecializedPartial(instance, subs, partials, stackSubs, stackPartials, childText) {
+  function createSpecializedPartial(instance, subs, partials, stackSubs, stackPartials, stackText) {
     function PartialTemplate() {};
     PartialTemplate.prototype = instance;
     function Substitutions() {};
@@ -295,9 +297,9 @@ var Hogan = {};
 
     stackSubs = stackSubs || {};
     partial.stackSubs = stackSubs;
+    partial.subsText = stackText;
     for (key in subs) {
       if (!stackSubs[key]) stackSubs[key] = subs[key];
-      partial.subsText[key] = childText;
     }
     for (key in stackSubs) {
       partial.subs[key] = stackSubs[key];

--- a/test/index.js
+++ b/test/index.js
@@ -956,6 +956,20 @@ test("Top-level substitutions take precedence in multi-level inheritance", funct
   is(noSubChild, 'p', 'should use the parent\'s value');
 });
 
+test("Lambdas work in multi-level inheritance", function() {
+  var lambda = function() {
+    return function(text) {
+      return "changed " + text;
+    };
+  }
+  var child = Hogan.compile('{{<parent}}{{$a}}{{#lambda}}c{{/lambda}}{{/a}}{{/parent}}').render({lambda:lambda}, {
+    parent: '{{<older}}{{$a}}p{{/a}}{{$b}}{{#lambda}}p{{/lambda}}{{/b}}{{/older}}',
+    older: '{{<grandParent}}{{$a}}o{{/a}}{{$c}}{{#lambda}}o{{/lambda}}{{/c}}{{/grandParent}}',
+    grandParent: '{{$a}}g{{/a}} - {{$b}}g{{/b}} - {{$c}}g{{/c}} - {{#lambda}}g{{/lambda}}'
+  });
+  is(child, 'changed c - changed p - changed o - changed g', 'should be changed child value');
+});
+
 /* Safety tests */
 
 test("Updates object state", function() {


### PR DESCRIPTION
Lambdas in multi-level inheritance situations are currently being substituted incorrectly. This PR should fix that. The problem is that the test to see if activeSub undefined was always returning true for this situation and the text at the highest level was always being used.
