### PR TITLE
Fix malformed component.json

### DIFF
--- a/component.json
+++ b/component.json
@@ -21,7 +21,7 @@
     }
   ]
   , "ignore" : [
-    ,"tools"
+    "tools"
     ,"wrappers"
     ,".*"
   ]


### PR DESCRIPTION
bower install/update will fail because component.json is malformed.
[component.json Line 24](https://github.com/twitter/hogan.js/blob/master/component.json#L24)
[Fix issue #191](https://github.com/twitter/hogan.js/issues/191)
