### PR TITLE
Fixes issue #194.

### DIFF
--- a/lib/template.js
+++ b/lib/template.js
@@ -196,11 +196,11 @@ var Hogan = {};
     },
 
     // higher order templates
-    ls: function(func, cx, partials, text, tags) {
+    ls: function(func, cx, ctx, partials, text, tags) {
       var oldTags = this.options.delimiters;
 
       this.options.delimiters = tags;
-      this.b(this.ct(coerceToString(func.call(cx, text)), cx, partials));
+      this.b(this.ct(coerceToString(func.call(cx, text, ctx)), cx, partials));
       this.options.delimiters = oldTags;
 
       return false;
@@ -230,7 +230,7 @@ var Hogan = {};
           return true;
         } else {
           textSource = (this.activeSub && this.subsText && this.subsText[this.activeSub]) ? this.subsText[this.activeSub] : this.text;
-          return this.ls(result, cx, partials, textSource.substring(start, end), tags);
+          return this.ls(result, cx, ctx, partials, textSource.substring(start, end), tags);
         }
       }
 

--- a/test/index.js
+++ b/test/index.js
@@ -565,6 +565,25 @@ test("Section Extensions In Higher Order Sections", function() {
   is(s, "Testbarqux", "unprocessed test");
 });
 
+test("Section Extension With Higher Order Sections Access Outer Context ", function() {
+  var text = "{{#inner}}{{#extension}}{{outerValue}}{{/extension}}{{/inner}}"
+  var t = Hogan.compile(text);
+  var context = {
+    outerValue: "Outer value",
+    inner: {
+      innerValue: "Inner value"
+    },
+    extension: function () {
+      return function (tmpl, ctx) {
+        var key = /{{(.*)}}/.exec(tmpl)[1];
+        return ctx[0][key];
+      }
+    }
+  };
+  var s = t.render(context);
+  is(s, "Outer value", "unprocessed test");
+});
+
 test("Section Extensions In Lambda Replace Variable", function() {
   var text = "Test{{foo}}";
   var options = {sectionTags:[{o:'_baz', c:'baz'}]};


### PR DESCRIPTION
Allow sections extensions with outer sections to access the properties
of outer contexts. This allows for section extensions to behave like
hogan.js does internally when looking up properties directly in
templates.
