### PR TITLE
Don't overwrite global `key` variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-## Hogan.js - A mustache compiler. [![Build Status](https://secure.travis-ci.org/twitter/hogan.js.png)](http://travis-ci.org/twitter/hogan.js)
+## Hogan.js - A mustache compiler. [![No Maintenance Intended](http://unmaintained.tech/badge.svg)](http://unmaintained.tech/ "This project is not actively maintained")
+
 
 [Hogan.js](http://twitter.github.io/hogan.js/) is a compiler for the
 [Mustache](http://mustache.github.io/) templating language. For information

--- a/lib/template.js
+++ b/lib/template.js
@@ -48,6 +48,7 @@ var Hogan = {};
 
     // ensurePartial
     ep: function(symbol, partials) {
+      var key;
       var partial = this.partials[symbol];
 
       // check to see that if we've instantiated this partial before


### PR DESCRIPTION
Added missing var declaration needed for `for (key in partial.subs)`
