### PR TITLE
hulk: use a require-friendly AMD name

### DIFF
--- a/bin/hulk
+++ b/bin/hulk
@@ -1,4 +1,4 @@
-#!/usr/bin/env nodejs
+#!/usr/bin/env node
 
 /*
  *  Copyright 2011 Twitter, Inc.

--- a/bin/hulk
+++ b/bin/hulk
@@ -1,4 +1,4 @@
-#!/usr/bin/env node
+#!/usr/bin/env nodejs
 
 /*
  *  Copyright 2011 Twitter, Inc.

--- a/bin/hulk
+++ b/bin/hulk
@@ -121,7 +121,7 @@ function removeByteOrderMark(text) {
 function wrap(file, name, openedFile) {
   switch(options.wrapper) {
     case "amd":
-      return 'define('+ (!options.outputdir ? '"' + path.join(path.dirname(file), name) + '", ' : '') + '[ "hogan.js" ], function(Hogan){ return new Hogan.Template(' + hogan.compile(openedFile, { asString: 1 }) + ');});';
+      return 'define('+ (!options.outputdir ? '"' + path.join(path.dirname(file), name) + '", ' : '') + '[ "hogan" ], function(Hogan){ return new Hogan.Template(' + hogan.compile(openedFile, { asString: 1 }) + ');});';
     default:
       return (options.variable || 'templates') 
         + '["' + name + '"] = new Hogan.Template(' 


### PR DESCRIPTION
Change 'hogan.js' to 'hogan' in AMD template dependency.

This makes loading templates play nicer with require-2.1.9.
