### PR TITLE
Adding hasOwnProperty check to stop lookup on the prototype

### DIFF
--- a/lib/template.js
+++ b/lib/template.js
@@ -266,7 +266,7 @@ var Hogan = {};
 
     if (scope && typeof scope == 'object') {
 
-      if (scope[key] !== undefined) {
+      if (scope[key] !== undefined && scope.hasOwnProperty(key)) {
         val = scope[key];
 
       // try lookup with get for backbone or similar model data


### PR DESCRIPTION
I had a key called 'values' in my data object but findInScope was finding `Array.prototype.values`, causing my template to not render properly. See jsfiddle: http://jsfiddle.net/h8v2goby/

Added a hasOwnProperty check to fix this.
