### PR TITLE
add es6 option to hulk --wrapper

### DIFF
--- a/bin/hulk
+++ b/bin/hulk
@@ -27,20 +27,20 @@ var hogan  = require('../lib/hogan.js')
 // locals
 var specials       = ['/', '.', '*', '+', '?', '|','(', ')', '[', ']', '{', '}', '\\']
   , specialsRegExp = new RegExp('(\\' + specials.join('|\\') + ')', 'g')
-  , options        = { 
-    'namespace': String, 
-    'outputdir': path, 
-    'variable': String, 
-    'wrapper': String, 
+  , options        = {
+    'namespace': String,
+    'outputdir': path,
+    'variable': String,
+    'wrapper': String,
     'version': true,
     'help': true
     }
-  , shortHand      = { 
+  , shortHand      = {
     'n': ['--namespace'],
-    'o': ['--outputdir'], 
-    'v': ['--variable'], 
-    'w': ['--wrapper'], 
-    'h': ['--help'], 
+    'o': ['--outputdir'],
+    'v': ['--variable'],
+    'w': ['--wrapper'],
+    'h': ['--help'],
     'v': ['--version']
     }
   , templates;
@@ -118,14 +118,20 @@ function removeByteOrderMark(text) {
 
 
 // wrap templates
-function wrap(file, name, openedFile) {
+function wrap(file, name, openedFile, position) {
   switch(options.wrapper) {
     case "amd":
       return 'define('+ (!options.outputdir ? '"' + path.join(path.dirname(file), name) + '", ' : '') + '[ "hogan.js" ], function(Hogan){ return new Hogan.Template(' + hogan.compile(openedFile, { asString: 1 }) + ');});';
+    case "es6":
+      var importStatement = position == 0 ? "import Hogan from 'hogan.js'; \n" : "";
+      return importStatement
+        + 'export var ' + name + ' = new Hogan.Template('
+        + hogan.compile(openedFile, { asString: 1 })
+        + ');'
     default:
-      return (options.variable || 'templates') 
-        + '["' + name + '"] = new Hogan.Template(' 
-        + hogan.compile(openedFile, { asString: 1 }) 
+      return (options.variable || 'templates')
+        + '["' + name + '"] = new Hogan.Template('
+        + hogan.compile(openedFile, { asString: 1 })
         + ');';
   }
 }
@@ -145,12 +151,12 @@ function namespace(name) {
 
 // write a template foreach file that matches template extension
 templates = extractFiles(options.argv.remain)
-  .map(function (file) {
+  .map(function (file, i) {
     var openedFile = fs.readFileSync(file, 'utf-8'), name;
     if (!openedFile) return;
     name = namespace(path.basename(file).replace(/\..*$/, ''));
     openedFile = removeByteOrderMark(openedFile.trim());
-    openedFile = wrap(file, name, openedFile);
+    openedFile = wrap(file, name, openedFile, i);
     if (!options.outputdir) return openedFile;
     var vn = options.variable || 'templates';
     fs.writeFileSync(path.join(options.outputdir, name + '.js')


### PR DESCRIPTION
# Add Wrapper Option to Hulk for ES6 Modules

Was working on a project recently that used ES6 modules and hogan.js. I needed a way to load compiled templates (compiled with hulk) with the ES6 module loader. Essentially this adds `--wrapper es6`. If you compile with this option, hulk generates a file that imports hogan.js as a dependency, then exports each template as part of the module. Say you had a folder named `templates` with two templates inside `user.mustache` and `product.mustache`. Now when you run `hulk templates/*.mustache -w es6 > templates.js` the following will be output to `templates.js`:

```
import Hogan from 'hogan.js'; 
export var users = new Hogan.Template({...etc});
export var products = new Hogan.Template({...etc});
```

Now, in your other modules, you can load these templates like this:

```
import * as templates from './templates.js';
```

That would make each compiled template available off thte `templates` variable, so you could render the above users template like this:

```
templates.users.render(/* data */);
```

This has proved to be pretty rad for the project, so I thought I'd open a pr from my fork and see if you guys were interested.

Also, my editor automatically strips trailing whitespace, sorry that partially obscures the meat of this pull request... :grimacing: 