### PR TITLE
Allow implicit iteration over the root context element

### DIFF
--- a/lib/template.js
+++ b/lib/template.js
@@ -141,7 +141,7 @@ var Hogan = {};
           doModelGet = this.options.modelGet,
           cx = null;
 
-      if (key === '.' && isArray(ctx[ctx.length - 2])) {
+      if (key === '.' && (ctx.length === 1 || isArray(ctx[ctx.length - 2]))) {
         val = ctx[ctx.length - 1];
       } else {
         for (var i = 1; i < names.length; i++) {

--- a/test/index.js
+++ b/test/index.js
@@ -691,6 +691,13 @@ test("Implicit Iterator", function() {
   is(s, " 42  43  44 ", "implicit iterators work");
 });
 
+test("Root-level Implicit Iterator", function() {
+  var text = '{{#.}} {{name}} {{/.}}';
+  var t = Hogan.compile(text);
+  var s = t.render([{name:"a"},{name:"b"}]);
+  is(s, " a  b ", "root-level implicit iterators work");
+});
+
 test("Partials And Delimiters", function() {
   var text = '{{>include}}*\n{{= | | =}}\n*|>include|';
   var partialText = ' .{{value}}. ';


### PR DESCRIPTION
This fixes #154 and generally matches Mustache.js’s behavior. Since there’s no test for this in the Mustache spec (see https://github.com/mustache/spec/issues/87), I’ve added a unit test for it.

It’d be really nice to have this added in—I recently dealt with a confusing moment when transitioning some Mustache templates that used this pattern to Hogan. If the bug is any indication, it’s tripped up others, too.