### PR TITLE
Update license attribute

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,11 +10,7 @@
     "type": "git"
     , "url": "https://github.com/twitter/hogan.js.git"
   }
-  , "licenses": [
-    { "type": "Apache-2.0"
-      , "url": "http://www.apache.org/licenses/LICENSE-2.0"
-    }
-  ]
+  , "license": "Apache-2.0"
   , "dependencies" : {
       "nopt" : "1.0.10"
     , "mkdirp": "0.3.0"


### PR DESCRIPTION
specifying the type and URL is deprecated:

https://docs.npmjs.com/files/package.json#license
http://npm1k.org/