### PR TITLE
Make the script example scrollable so it can be copied easily

### DIFF
--- a/stylesheets/layout.css
+++ b/stylesheets/layout.css
@@ -172,7 +172,7 @@ pre, code {
 	padding: 5px 10px;
 	margin-bottom: 20px;
 	font-family: courier;
-	overflow: hidden;
+	overflow: auto;
 }
 
 pre code {


### PR DESCRIPTION
I ran into "problems" while trying to copy the script tag on into my code. It's this one here:

![script_tag](https://cloud.githubusercontent.com/assets/1185253/10300936/5d18c484-6bfd-11e5-82c0-afcee1175dde.png)

The `pre`/`code` tags are not scrollable and I had to change the `overflow` attribute in my browser dev tools to copy the script tag.

Now, this commit makes this change permanent and allows to scroll/copy the example script tag again.

What do you think? Another solution I thought of was to change the layout and move the whole script tag code snippet and the text to a separate row:

![2015-10-06 at 07 31](https://cloud.githubusercontent.com/assets/1185253/10300956/930eda38-6bfd-11e5-817c-4169928bff0c.png)

If this is a better solution (since the scrollbars might look ugly on different systems), I'll happily close this PR and open another one with the separate row.