### PR TITLE
{{{foo}}} when foo is a plain JS object should return JSON

### DIFF
--- a/lib/template.js
+++ b/lib/template.js
@@ -319,6 +319,8 @@ var Hogan = {};
       hChars = /[&<>\"\']/;
 
   function coerceToString(val) {
+    if (typeof (val) === 'object' && val !== null && val.toString === Object.prototype.toString)
+      return (JSON.stringify(val));
     return String((val === null || val === undefined) ? '' : val);
   }
 


### PR DESCRIPTION
While it's not made clear in the spec, it seems most other implementations of mustache (and certainly the original Ruby one) spit out a nested object/hash/dict as some parseable form for their host language.

Example:

``` ruby
require 'mustache'
Mustache.render("hi {{{foo}}}", {:foo => {:bar => 123, :test => "abc"}})
# => "hi {:bar=>123, :test=>\"abc\"}"
```

Currently in this case on Hogan.js, we just spit out `[object Object]`, which is not very useful:

``` javascript
var Hogan = require('hogan.js');
var tpl = Hogan.compile('hi {{{foo}}}');
tpl.render({foo: {bar: 123, test: 'abc'}})
// => "hi [object Object]"
```

 This patch amends `coerceToString` to return JSON when we're asked to output a nested plain JS object (ie, one without its own `toString` implementation), so the output for the case above changes to `"hi {\"bar\": 123, \"test\": \"abc\"}"`
