### PR TITLE
Fix extraneous semicolon on inverted sections

### DIFF
--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -338,7 +338,7 @@
     '^': function(node, context) {
       context.code += 'if(!t.s(t.' + chooseMethod(node.n) + '("' + esc(node.n) + '",c,p,1),c,p,1,0,0,"")){';
       Hogan.walk(node.nodes, context);
-      context.code += '};';
+      context.code += '}';
     },
 
     '>': createPartial,


### PR DESCRIPTION
Semicolon termination of an 'if' block for inverted sections can cause
errors under jshint and other linting programs, and is unnecessary.