### PR TITLE
adding support for leading dot. adding use of prototypical inheritance for Stack's substitutions and partials

### DIFF
--- a/lib/template.js
+++ b/lib/template.js
@@ -73,7 +73,7 @@ var Hogan = {};
       if (partial.subs) {
         // Make sure we consider parent template now
         if (!partials.stackText) partials.stackText = {};
-        for (key in partial.subs) {
+        for (var key in partial.subs) {
           if (!partials.stackText[key]) {
             partials.stackText[key] = (this.activeSub !== undefined && partials.stackText[this.activeSub]) ? partials.stackText[this.activeSub] : this.text;
           }
@@ -277,17 +277,25 @@ var Hogan = {};
   }
 
   function createSpecializedPartial(instance, subs, partials, stackSubs, stackPartials, stackText) {
-    function PartialTemplate() {};
+    function PartialTemplate() {}
     PartialTemplate.prototype = instance;
-    function Substitutions() {};
+
+    function Substitutions() {}
     Substitutions.prototype = instance.subs;
+
+    function StackSubstitutions() {}
+    StackSubstitutions.prototype = stackSubs || {};
+
+    function StackPartials() {}
+    StackPartials.prototype = stackPartials || {};
+
     var key;
     var partial = new PartialTemplate();
     partial.subs = new Substitutions();
     partial.subsText = {};  //hehe. substext.
     partial.buf = '';
 
-    stackSubs = stackSubs || {};
+    stackSubs = new StackSubstitutions();
     partial.stackSubs = stackSubs;
     partial.subsText = stackText;
     for (key in subs) {
@@ -297,7 +305,7 @@ var Hogan = {};
       partial.subs[key] = stackSubs[key];
     }
 
-    stackPartials = stackPartials || {};
+    stackPartials = new StackPartials();
     partial.stackPartials = stackPartials;
     for (key in partials) {
       if (!stackPartials[key]) stackPartials[key] = partials[key];

--- a/lib/template.js
+++ b/lib/template.js
@@ -127,7 +127,7 @@ var Hogan = {};
       pass = !!val;
 
       if (!inverted && pass && ctx) {
-        ctx.push((typeof val == 'object') ? val : ctx[ctx.length - 1]);
+        ctx.push(val);
       }
 
       return pass;
@@ -137,13 +137,11 @@ var Hogan = {};
     d: function(key, ctx, partials, returnFound) {
       var found,
           names = key.split('.'),
-          val = this.f(names[0], ctx, partials, returnFound),
+          val = names[0] === '' ? ctx[ctx.length - 1] : this.f(names[0], ctx, partials, returnFound),
           doModelGet = this.options.modelGet,
           cx = null;
 
-      if (key === '.' && isArray(ctx[ctx.length - 2])) {
-        val = ctx[ctx.length - 1];
-      } else {
+      if (key !== '.') {
         for (var i = 1; i < names.length; i++) {
           found = findInScope(names[i], val, doModelGet);
           if (found !== undefined) {

--- a/test/index.js
+++ b/test/index.js
@@ -1042,6 +1042,18 @@ test("Lambdas work in multi-level inheritance", function() {
   is(child, 'changed c - changed p - changed o - changed g', 'should be changed child value');
 });
 
+test("Substitutions used in call for one partial template should not affect other during multi-level inheritance", function() {
+    var subPartial = Hogan.compile("Haloha!{{$replace}}replace me{{/replace}}");
+    var partial = Hogan.compile("{{>subPartial}} {{<subPartial}}{{$replace}}replaced1{{/replace}}{{/subPartial}} {{<subPartial}}{{$replace}}replaced2{{/replace}}{{/subPartial}}");
+    var t = Hogan.compile("{{>partial}}");
+
+    var s = t.render({}, {
+        subPartial: subPartial,
+        partial: partial
+    });
+    is(s, "Haloha!replace me Haloha!replaced1 Haloha!replaced2", "Substitutions are correctly handled during multi-level inheritance");
+});
+
 /* Safety tests */
 
 test("Updates object state", function() {

--- a/test/index.js
+++ b/test/index.js
@@ -684,6 +684,13 @@ test("Dotted Names", function() {
   is(s, '"Joe" == "Joe"', "dotted names work");
 });
 
+test("Leading Dot", function() {
+  var text = "{{#items}}{{.title}}{{/items}}";
+  var t = Hogan.compile(text);
+  var s = t.render({items: [{title: 'a'}, {title: 'b'}, {}], title: 'ha'});
+  is(s, "ab", "leading dot forces lookup on top context");
+});
+
 test("Implicit Iterator", function() {
   var text = '{{#stuff}} {{.}} {{/stuff}}';
   var t = Hogan.compile(text);


### PR DESCRIPTION
There was new feature proposed which is in line with the current spec(which isn't updating for years :() here: https://github.com/mustache/spec/issues/52

It's been implemented in some of the Mustache implementations already and is backward compatible. It should allow us avoid issues when some key is missing in top context and engine is looking for that variable in parent contexts. 
