### PR TITLE
Added opportunity to iterate an object deeply

### DIFF
--- a/lib/template.js
+++ b/lib/template.js
@@ -143,6 +143,13 @@ var Hogan = {};
 
       if (key === '.' && isArray(ctx[ctx.length - 2])) {
         val = ctx[ctx.length - 1];
+        if (typeof val === 'object') {
+          var obj = val;
+          val = [];
+          for(var prop in obj) {
+            val.push(obj[prop]);
+          }
+        }
       } else {
         for (var i = 1; i < names.length; i++) {
           found = findInScope(names[i], val, doModelGet);


### PR DESCRIPTION
Hi there!
I have an array of objects that looks like this:

```
  array = [
    {name: 'name1', something1: 'value1', something2: 'value2'}
    {name: 'name2', something3: 'value3', something4: 'value4'}
    ...
    {name: 'nameN', somethingA: 'valueA', somethingB: 'valueB'}
  ]
```

I wanna render the template:

```
  {{#array}}
    <tr data-name="{{name}}">
      {{#.}} //object
        <td>{{ . }}</td> //property of the object
      {{/.}}
    </tr>
  {{#/array}}
```

I get the following html:
```
  <tr data-name>
    <td></td>
  </tr>
  <tr data-name>
    <td></td>
  </tr>
  ...
  <tr data-name>
    <td></td>
  </tr>
```

But I would like this:
```
  <tr data-name="name1">
    <td>value1</td>
    <td>value2</td>
  </tr>
  <tr data-name="name2">
    <td>value3</td>
    <td>value4</td>
  </tr>
  ...
  <tr data-name="nameN">
    <td>valueA</td
    <td>valueB</td>
  </tr>
```

So, I send the pull request which does this possible.
Now I can even iterate the object:

```
obj1 = {
  obj2: {
    prop1: 'value1',
    prop2: 'value2'
  }
}
```

Using this template:
```
{{#.}} //obj1
  {{#.}} //obj2
    {{.}} //prop1, prop2, etc...
  {{/.}}
{{/.}}

```
