### PR TITLE
Use https instead of http in urls

### DIFF
--- a/component.json
+++ b/component.json
@@ -9,7 +9,7 @@
     "lib/hogan.js",
     "lib/template.js"
   ]
-  , "homepage": "http://twitter.github.com/hogan.js/"
+  , "homepage": "https://twitter.github.com/hogan.js/"
   , "author": "Twitter Inc."
   , "repository": {
     "type": "git"

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   , "version": "3.0.2"
   , "keywords": ["mustache", "template"]
   , "main": "./lib/hogan.js"
-  , "homepage": "http://twitter.github.com/hogan.js/"
+  , "homepage": "https://twitter.github.com/hogan.js/"
   , "author": "Twitter Inc."
   , "repository": {
     "type": "git"

--- a/web/index.html.mustache
+++ b/web/index.html.mustache
@@ -11,9 +11,9 @@
 	<title>Hogan.js</title>
 	<meta name="description" content="">
 	<meta name="author" content="">
-	<script src="http://twitter.github.io/hogan.js/builds/{{version}}/hogan-{{version}}.js"></script>
+	<script src="https://twitter.github.io/hogan.js/builds/{{version}}/hogan-{{version}}.js"></script>
 	<!--[if lt IE 9]>
-		<script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
+		<script src="https://html5shim.googlecode.com/svn/trunk/html5.js"></script>
 	<![endif]-->
 
 	<!-- Mobile Specific Metas
@@ -58,7 +58,7 @@
 			<p>
 				Alternatively, drop hogan.js in your browser by adding the following script.
 			</p>
-			<pre><code>&lt;script src="http://twitter.github.com/hogan.js/builds/{{version}}/hogan-{{version}}.js"&gt;&lt;/script&gt;</code></pre>
+			<pre><code>&lt;script src="https://twitter.github.com/hogan.js/builds/{{version}}/hogan-{{version}}.js"&gt;&lt;/script&gt;</code></pre>
 
 		</div>
 		<div class="ten columns offset-by-one">


### PR DESCRIPTION
This PR changes every instance of an http url to its https version for security reasons.