### PR TITLE
docs: Fix simple typo, curent -> current

### DIFF
--- a/web/1.0.0/hogan.js
+++ b/web/1.0.0/hogan.js
@@ -30,7 +30,7 @@ var HoganTemplate = (function () {
       return this.r(context, partials);
     },
 
-    // tries to find a partial in the curent scope and render it
+    // tries to find a partial in the current scope and render it
     rp: function(name, context, partials, indent) {
       var partial = partials[name];
 

--- a/web/builds/1.0.0/hogan.js
+++ b/web/builds/1.0.0/hogan.js
@@ -30,7 +30,7 @@ var HoganTemplate = (function () {
       return this.r(context, partials);
     },
 
-    // tries to find a partial in the curent scope and render it
+    // tries to find a partial in the current scope and render it
     rp: function(name, context, partials, indent) {
       var partial = partials[name];
 

--- a/web/builds/1.0.3/hogan.js
+++ b/web/builds/1.0.3/hogan.js
@@ -31,7 +31,7 @@ var HoganTemplate = (function () {
       return this.r(context, partials, indent);
     },
 
-    // tries to find a partial in the curent scope and render it
+    // tries to find a partial in the current scope and render it
     rp: function(name, context, partials, indent) {
       var partial = partials[name];
 

--- a/web/builds/1.0.4/hogan-1.0.4.amd.js
+++ b/web/builds/1.0.4/hogan-1.0.4.amd.js
@@ -42,7 +42,7 @@ var Hogan = {};
       return this.r(context, partials, indent);
     },
 
-    // tries to find a partial in the curent scope and render it
+    // tries to find a partial in the current scope and render it
     rp: function(name, context, partials, indent) {
       var partial = partials[name];
 

--- a/web/builds/1.0.4/hogan-1.0.4.common.js
+++ b/web/builds/1.0.4/hogan-1.0.4.common.js
@@ -42,7 +42,7 @@ var Hogan = {};
       return this.r(context, partials, indent);
     },
 
-    // tries to find a partial in the curent scope and render it
+    // tries to find a partial in the current scope and render it
     rp: function(name, context, partials, indent) {
       var partial = partials[name];
 

--- a/web/builds/1.0.4/hogan-1.0.4.js
+++ b/web/builds/1.0.4/hogan-1.0.4.js
@@ -42,7 +42,7 @@ var Hogan = {};
       return this.r(context, partials, indent);
     },
 
-    // tries to find a partial in the curent scope and render it
+    // tries to find a partial in the current scope and render it
     rp: function(name, context, partials, indent) {
       var partial = partials[name];
 

--- a/web/builds/1.0.4/hogan-1.0.4.mustache.js
+++ b/web/builds/1.0.4/hogan-1.0.4.mustache.js
@@ -44,7 +44,7 @@ var Hogan = {};
       return this.r(context, partials, indent);
     },
 
-    // tries to find a partial in the curent scope and render it
+    // tries to find a partial in the current scope and render it
     rp: function(name, context, partials, indent) {
       var partial = partials[name];
 

--- a/web/builds/1.0.4/template-1.0.4.js
+++ b/web/builds/1.0.4/template-1.0.4.js
@@ -40,7 +40,7 @@ var Hogan = {};
       return this.r(context, partials, indent);
     },
 
-    // tries to find a partial in the curent scope and render it
+    // tries to find a partial in the current scope and render it
     rp: function(name, context, partials, indent) {
       var partial = partials[name];
 

--- a/web/builds/1.0.5/hogan-1.0.5.amd.js
+++ b/web/builds/1.0.5/hogan-1.0.5.amd.js
@@ -45,7 +45,7 @@ var Hogan = {};
       return this.r(context, partials, indent);
     },
 
-    // tries to find a partial in the curent scope and render it
+    // tries to find a partial in the current scope and render it
     rp: function(name, context, partials, indent) {
       var partial = partials[name];
 

--- a/web/builds/1.0.5/hogan-1.0.5.common.js
+++ b/web/builds/1.0.5/hogan-1.0.5.common.js
@@ -45,7 +45,7 @@ var Hogan = {};
       return this.r(context, partials, indent);
     },
 
-    // tries to find a partial in the curent scope and render it
+    // tries to find a partial in the current scope and render it
     rp: function(name, context, partials, indent) {
       var partial = partials[name];
 

--- a/web/builds/1.0.5/hogan-1.0.5.js
+++ b/web/builds/1.0.5/hogan-1.0.5.js
@@ -45,7 +45,7 @@ var Hogan = {};
       return this.r(context, partials, indent);
     },
 
-    // tries to find a partial in the curent scope and render it
+    // tries to find a partial in the current scope and render it
     rp: function(name, context, partials, indent) {
       var partial = partials[name];
 

--- a/web/builds/1.0.5/hogan-1.0.5.mustache.js
+++ b/web/builds/1.0.5/hogan-1.0.5.mustache.js
@@ -47,7 +47,7 @@ var Hogan = {};
       return this.r(context, partials, indent);
     },
 
-    // tries to find a partial in the curent scope and render it
+    // tries to find a partial in the current scope and render it
     rp: function(name, context, partials, indent) {
       var partial = partials[name];
 

--- a/web/builds/1.0.5/template-1.0.5.js
+++ b/web/builds/1.0.5/template-1.0.5.js
@@ -43,7 +43,7 @@ var Hogan = {};
       return this.r(context, partials, indent);
     },
 
-    // tries to find a partial in the curent scope and render it
+    // tries to find a partial in the current scope and render it
     rp: function(name, context, partials, indent) {
       var partial = partials[name];
 

--- a/web/builds/2.0.0/hogan-2.0.0.amd.js
+++ b/web/builds/2.0.0/hogan-2.0.0.amd.js
@@ -45,7 +45,7 @@ var Hogan = {};
       return this.r(context, partials, indent);
     },
 
-    // tries to find a partial in the curent scope and render it
+    // tries to find a partial in the current scope and render it
     rp: function(name, context, partials, indent) {
       var partial = partials[name];
 

--- a/web/builds/2.0.0/hogan-2.0.0.common.js
+++ b/web/builds/2.0.0/hogan-2.0.0.common.js
@@ -45,7 +45,7 @@ var Hogan = {};
       return this.r(context, partials, indent);
     },
 
-    // tries to find a partial in the curent scope and render it
+    // tries to find a partial in the current scope and render it
     rp: function(name, context, partials, indent) {
       var partial = partials[name];
 

--- a/web/builds/2.0.0/hogan-2.0.0.js
+++ b/web/builds/2.0.0/hogan-2.0.0.js
@@ -45,7 +45,7 @@ var Hogan = {};
       return this.r(context, partials, indent);
     },
 
-    // tries to find a partial in the curent scope and render it
+    // tries to find a partial in the current scope and render it
     rp: function(name, context, partials, indent) {
       var partial = partials[name];
 

--- a/web/builds/2.0.0/hogan-2.0.0.mustache.js
+++ b/web/builds/2.0.0/hogan-2.0.0.mustache.js
@@ -47,7 +47,7 @@ var Hogan = {};
       return this.r(context, partials, indent);
     },
 
-    // tries to find a partial in the curent scope and render it
+    // tries to find a partial in the current scope and render it
     rp: function(name, context, partials, indent) {
       var partial = partials[name];
 

--- a/web/builds/2.0.0/template-2.0.0.js
+++ b/web/builds/2.0.0/template-2.0.0.js
@@ -43,7 +43,7 @@ var Hogan = {};
       return this.r(context, partials, indent);
     },
 
-    // tries to find a partial in the curent scope and render it
+    // tries to find a partial in the current scope and render it
     rp: function(name, context, partials, indent) {
       var partial = partials[name];
 


### PR DESCRIPTION
There is a small typo in web/1.0.0/hogan.js, web/builds/1.0.0/hogan.js, web/builds/1.0.3/hogan.js, web/builds/1.0.4/hogan-1.0.4.amd.js, web/builds/1.0.4/hogan-1.0.4.common.js, web/builds/1.0.4/hogan-1.0.4.js, web/builds/1.0.4/hogan-1.0.4.mustache.js, web/builds/1.0.4/template-1.0.4.js, web/builds/1.0.5/hogan-1.0.5.amd.js, web/builds/1.0.5/hogan-1.0.5.common.js, web/builds/1.0.5/hogan-1.0.5.js, web/builds/1.0.5/hogan-1.0.5.mustache.js, web/builds/1.0.5/template-1.0.5.js, web/builds/2.0.0/hogan-2.0.0.amd.js, web/builds/2.0.0/hogan-2.0.0.common.js, web/builds/2.0.0/hogan-2.0.0.js, web/builds/2.0.0/hogan-2.0.0.mustache.js, web/builds/2.0.0/template-2.0.0.js.

Should read `current` rather than `curent`.

