### PR TITLE
Update mkdirp package

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   , "license": "Apache-2.0"
   , "dependencies" : {
       "nopt" : "1.0.10"
-    , "mkdirp": "0.3.0"
+    , "mkdirp": "0.5.5"
     }
   , "devDependencies": {
       "uglify-js": "2.x"


### PR DESCRIPTION
```
deprecated mkdirp@0.3.0: Legacy versions of mkdirp are no longer supported. Please update to mkdirp 1.x. (Note that the API surface has changed to use Promises in 1.x.)
```