### PR TITLE
Harden against prototype pollution.

### DIFF
--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -319,8 +319,8 @@
   }
 
   function createPartial(node, context) {
-    var prefix = context.hasOwnProperty('prefix') ? context.prefix : '');
-    var sym = "<" + (prefix || '') + node.n + serialNo++;
+    var prefix = context.hasOwnProperty('prefix') ? context.prefix : '';
+    var sym = "<" + prefix + node.n + serialNo++;
     context.partials[sym] = {name: node.n, partials: {}};
     var indent = node.hasOwnProperty('indent') ? node.indent : '';
     context.code += 't.b(t.rp("' +  esc(sym) + '",c,p,"' + (indent || '') + '"));';
@@ -396,7 +396,8 @@
 
   Hogan.parse = function(tokens, text, options) {
     options = options || {};
-    return buildTree(tokens, '', [], (options.hasOwnProperty("sectionTags") && options.sectionTags || []);
+    var sectionTags = options.hasOwnProperty("sectionTags") ? options.sectionTags : [];
+    return buildTree(tokens, '', [], (sectionTags || []));
   }
 
   Hogan.cache = {};

--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -319,7 +319,7 @@
   }
 
   function createPartial(node, context) {
-    var prefix = "<" + (context.prefix || "");
+    var prefix = "<" + ((context.hasOwnProperty("prefix") && context.prefix) || "");
     var sym = prefix + node.n + serialNo++;
     context.partials[sym] = {name: node.n, partials: {}};
     context.code += 't.b(t.rp("' +  esc(sym) + '",c,p,"' + ((node.hasOwnProperty("indent") && node.indent) || '') + '"));';

--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -319,10 +319,11 @@
   }
 
   function createPartial(node, context) {
-    var prefix = "<" + ((context.hasOwnProperty("prefix") && context.prefix) || "");
-    var sym = prefix + node.n + serialNo++;
+    var prefix = context.hasOwnProperty('prefix') ? context.prefix : '');
+    var sym = "<" + (prefix || '') + node.n + serialNo++;
     context.partials[sym] = {name: node.n, partials: {}};
-    context.code += 't.b(t.rp("' +  esc(sym) + '",c,p,"' + ((node.hasOwnProperty("indent") && node.indent) || '') + '"));';
+    var indent = node.hasOwnProperty('indent') ? node.indent : '';
+    context.code += 't.b(t.rp("' +  esc(sym) + '",c,p,"' + (indent || '') + '"));';
     return sym;
   }
 
@@ -395,7 +396,7 @@
 
   Hogan.parse = function(tokens, text, options) {
     options = options || {};
-    return buildTree(tokens, '', [], options.sectionTags || []);
+    return buildTree(tokens, '', [], (options.hasOwnProperty("sectionTags") && options.sectionTags || []);
   }
 
   Hogan.cache = {};

--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -320,7 +320,7 @@
 
   function createPartial(node, context) {
     var prefix = context.hasOwnProperty('prefix') ? context.prefix : '';
-    var sym = "<" + prefix + node.n + serialNo++;
+    var sym = "<" + (prefix || '') + node.n + serialNo++;
     context.partials[sym] = {name: node.n, partials: {}};
     var indent = node.hasOwnProperty('indent') ? node.indent : '';
     context.code += 't.b(t.rp("' +  esc(sym) + '",c,p,"' + (indent || '') + '"));';

--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -322,7 +322,7 @@
     var prefix = "<" + (context.prefix || "");
     var sym = prefix + node.n + serialNo++;
     context.partials[sym] = {name: node.n, partials: {}};
-    context.code += 't.b(t.rp("' +  esc(sym) + '",c,p,"' + (node.indent || '') + '"));';
+    context.code += 't.b(t.rp("' +  esc(sym) + '",c,p,"' + ((node.hasOwnProperty("indent") && node.indent) || '') + '"));';
     return sym;
   }
 


### PR DESCRIPTION
This makes it more difficult for RCEs in other libraries to overwrite the prototype chain to manipulate Hogan, but also prevents authors from manipulating the prototype chain on purpose. I think the latter is rare enough that this change is worth it.

This first patch just fixes `node.indent`. See #274.