### PR TITLE
upgrade Dependencies  "mkdirp": "1.0.4"  "jsdom": "20.0.0"  "rimraf":"3.0.2"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: node_js
 node_js:
-  - 0.6
+- node
+- lts/*
+- 10
 before_script:
   - "git submodule update --init"
   - "export DISPLAY=:99.0"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hogan.js"
   , "description": "A mustache compiler."
-  , "version": "3.0.2"
+  , "version": "3.0.3"
   , "keywords": ["mustache", "template"]
   , "main": "./lib/hogan.js"
   , "homepage": "https://twitter.github.com/hogan.js/"
@@ -13,13 +13,13 @@
   , "license": "Apache-2.0"
   , "dependencies" : {
       "nopt" : "1.0.10"
-    , "mkdirp": "0.3.0"
+    , "mkdirp": "1.0.4"
     }
   , "devDependencies": {
       "uglify-js": "2.x"
-    , "jsdom": "0.3.4"
+    , "jsdom": "20.0.0"
     , "step": "0.0.5"
-    , "rimraf": "2.0.1"
+    , "rimraf": "3.0.2"
   }
   , "bin" : { "hulk" : "./bin/hulk" }
 }


### PR DESCRIPTION
node: 16.16.0
npm: 7.24.2

Because some dependencies of the node version upgrade have been abandoned or there are security vulnerabilities, npm reports an error


npm WARN deprecated har-validator@5.1.5: this library is no longer supported
npm WARN deprecated graceful-fs@1.1.14: please upgrade to graceful-fs 4 for compatibility with current and future versions of Node.js
npm WARN deprecated uuid@3.4.0: Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.
npm WARN deprecated mkdirp@0.3.0: Legacy versions of mkdirp are no longer supported. Please update to mkdirp 1.x. (Note that the API surface has changed to use Promises in 1.x.)
npm WARN deprecated request@2.88.2: request has been deprecated, see https://github.com/request/request/issues/3142

@willnorris  @sayrer  @fat 

